### PR TITLE
Refactor Tamga config: rename logging parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ pip install tamga[all]              # All features
 ```python
 logger = Tamga(
     # Display settings
-    is_colored=True,        # Colored output
+    colored_output=True,        # Colored output
     show_time=True,         # Include timestamp
     show_timezone=False,    # Include timezone
 
     # Output destinations
-    log_to_file=True,        # Log to file
-    log_file="app.log",     # Log file path
+    file_output=True,        # Log to file
+    json_path="app.log",     # Log file path
     buffer_size=50,         # Buffer size for performance
 )
 ```
@@ -90,16 +90,16 @@ logger.dir("User action",
 ```python
 logger = Tamga(
     # File rotation
-    log_to_file=True,
-    max_log_size=50,         # 50MB max file size
+    file_output=True,
+    max_file_size_mb=50,         # 50MB max file size
     enable_backup=True,     # Create backups
 
     # Performance
     buffer_size=200,        # Larger buffer for production
-    log_to_console=False,    # Disable console for speed
+    console_output=False,    # Disable console for speed
 
     # External services
-    log_to_mongo=True,
+    mongo_output=True,
     mongo_uri="mongodb://...",
 
     # Multi-service notifications

--- a/examples/advanced_config.py
+++ b/examples/advanced_config.py
@@ -8,24 +8,24 @@ from tamga import Tamga
 # Advanced logger setup for production-like environments
 logger = Tamga(
     # File logging with rotation and backup
-    log_to_file=True,
-    log_file="logs/app.log",
+    file_output=True,
+    json_path="logs/app.log",
     max_log_size=50,  # 50 MB max file size
     enable_backup=True,  # Enable backup on rotation
     # JSON logging for log aggregation
-    log_to_json=True,
+    json_output=True,
     log_json="logs/app.json",
-    max_json_size=50,
+    max_json_size_mb=50,
     # SQLite logging for analytics
-    log_to_sql=True,
-    log_sql="logs/app.db",
-    sql_table="logs",
-    max_sql_size=100,
+    sql_output=True,
+    sql_path="logs/app.db",
+    sql_table_name="logs",
+    max_sql_size_mb=100,
     # Performance
     buffer_size=200,  # Large buffer for high throughput
-    log_to_console=False,  # Disable console for speed
+    console_output=False,  # Disable console for speed
     # MongoDB for centralized logging
-    log_to_mongo=bool(os.getenv("MONGO_URI")),
+    mongo_output=bool(os.getenv("MONGO_URI")),
     mongo_uri=os.getenv("MONGO_URI", ""),
     # Multi-service notifications for critical events
     notify_services=[

--- a/examples/fastapi_webapp.py
+++ b/examples/fastapi_webapp.py
@@ -7,12 +7,12 @@ from tamga import Tamga
 
 app = FastAPI()
 logger = Tamga(
-    log_to_console=True,
-    log_to_file=True,
-    log_file="fastapi_app.log",
+    console_output=True,
+    file_output=True,
+    json_path="fastapi_app.log",
     buffer_size=10,
     show_time=True,
-    is_colored=True,
+    colored_output=True,
 )
 
 

--- a/examples/high_performance.py
+++ b/examples/high_performance.py
@@ -11,10 +11,10 @@ from tamga import Tamga
 NUM_LOGS = 1_000_000  # One million log entries
 
 logger = Tamga(
-    log_to_file=True,
-    log_file="biglog.log",
+    file_output=True,
+    json_path="biglog.log",
     max_log_size=100,  # 100 MB max file size
-    log_to_console=False,  # Disable console for max speed
+    console_output=False,  # Disable console for max speed
     buffer_size=10_000,  # Large buffer for throughput
 )
 

--- a/llms.txt
+++ b/llms.txt
@@ -50,11 +50,11 @@ logger.critical("Database connection lost")
 ```python
 logger = Tamga(
     # Console output
-    is_colored=True,        # Enable colored output (default: True)
-    log_to_console=True,     # Enable console logging (default: True)
+    colored_output=True,        # Enable colored output (default: True)
+    console_output=True,     # Enable console logging (default: True)
 
     # Timestamp components
-    show_day=True,          # Show date (default: True)
+    show_date=True,          # Show date (default: True)
     show_time=True,         # Show time (default: True)
     show_timezone=False,    # Show timezone (default: False)
 )
@@ -65,18 +65,18 @@ logger = Tamga(
 ```python
 logger = Tamga(
     # File outputs
-    log_to_file=False,       # Enable file logging (default: False)
-    log_file="tamga.log",   # Log file path (default: "tamga.log")
+    file_output=False,       # Enable file logging (default: False)
+    json_path="tamga.log",   # Log file path (default: "tamga.log")
 
-    log_to_json=False,       # Enable JSON logging (default: False)
+    json_output=False,       # Enable JSON logging (default: False)
     log_json="tamga.json",  # JSON file path (default: "tamga.json")
 
-    log_to_sql=False,        # Enable SQLite logging (default: False)
-    log_sql="tamga.db",     # SQLite file path (default: "tamga.db")
-    sql_table="logs",       # Table name (default: "logs")
+    sql_output=False,        # Enable SQLite logging (default: False)
+    sql_path="tamga.db",     # SQLite file path (default: "tamga.db")
+    sql_table_name="logs",       # Table name (default: "logs")
 
     # External services
-    log_to_mongo=False,      # Enable MongoDB (default: False)
+    mongo_output=False,      # Enable MongoDB (default: False)
 )
 ```
 
@@ -89,8 +89,8 @@ logger = Tamga(
 
     # File rotation (in MB)
     max_log_size=10,         # Max log file size (default: 10)
-    max_json_size=10,        # Max JSON file size (default: 10)
-    max_sql_size=50,         # Max SQLite size (default: 50)
+    max_json_size_mb=10,        # Max JSON file size (default: 10)
+    max_sql_size_mb=50,         # Max SQLite size (default: 50)
     enable_backup=True,     # Create backups on rotation (default: True)
 )
 ```
@@ -99,7 +99,7 @@ logger = Tamga(
 
 ```python
 logger = Tamga(
-    log_to_mongo=True,
+    mongo_output=True,
     mongo_uri="mongodb+srv://user:pass@cluster.mongodb.net",
     mongo_database_name="tamga",      # Default: "tamga"
     mongo_collection_name="logs",     # Default: "logs"
@@ -259,20 +259,20 @@ import os
 
 logger = Tamga(
     # File logging with rotation
-    log_to_file=True,
-    log_file="logs/app.log",
+    file_output=True,
+    json_path="logs/app.log",
     max_log_size=50,
     enable_backup=True,
 
     # JSON for log aggregation
-    log_to_json=True,
+    json_output=True,
 
     # Performance optimization
-    log_to_console=False,
+    console_output=False,
     buffer_size=200,
 
     # Centralized logging
-    log_to_mongo=True,
+    mongo_output=True,
     mongo_uri=os.getenv("MONGO_URI"),
 
     # Multi-service notifications for critical events
@@ -296,8 +296,8 @@ logger = Tamga(
 
 ```python
 logger = Tamga(
-    log_to_file=True,
-    log_to_console=False,    # Disable console for speed
+    file_output=True,
+    console_output=False,    # Disable console for speed
     buffer_size=1000,       # Large buffer
 )
 
@@ -315,8 +315,8 @@ for i, record in enumerate(large_dataset):
 ```python
 logger = Tamga(
     # Maximum visibility
-    is_colored=True,
-    show_day=True,
+    colored_output=True,
+    show_date=True,
     show_time=True,
     show_timezone=True,
 
@@ -324,8 +324,8 @@ logger = Tamga(
     buffer_size=1,
 
     # Local file for debugging
-    log_to_file=True,
-    log_file="debug.log",
+    file_output=True,
+    json_path="debug.log",
 )
 ```
 
@@ -371,12 +371,12 @@ service_name = os.getenv("SERVICE_NAME", "unknown")
 
 logger = Tamga(
     # Service-specific collection
-    log_to_mongo=True,
+    mongo_output=True,
     mongo_collection_name=service_name,
 
     # Include service context
-    log_to_file=True,
-    log_file=f"logs/{service_name}.log",
+    file_output=True,
+    json_path=f"logs/{service_name}.log",
 )
 
 # Add service context to all logs
@@ -464,7 +464,7 @@ Tamga is thread-safe with locked buffer operations:
 ```python
 import threading
 
-logger = Tamga(log_to_file=True)
+logger = Tamga(file_output=True)
 
 def worker(worker_id):
     for i in range(100):
@@ -504,21 +504,21 @@ import os
 # Production-ready configuration
 logger = Tamga(
     # Console only in development
-    log_to_console=os.getenv("ENV") != "production",
+    console_output=os.getenv("ENV") != "production",
 
     # Always log to file
-    log_to_file=True,
-    log_file="logs/app.log",
+    file_output=True,
+    json_path="logs/app.log",
     max_log_size=50,
 
     # JSON for log aggregation
-    log_to_json=True,
+    json_output=True,
 
     # Performance settings
     buffer_size=100 if os.getenv("ENV") == "production" else 10,
 
     # MongoDB for centralized logging
-    log_to_mongo=bool(os.getenv("MONGO_URI")),
+    mongo_output=bool(os.getenv("MONGO_URI")),
     mongo_uri=os.getenv("MONGO_URI"),
 
     # Multi-service notifications

--- a/scripts/screenshot.py
+++ b/scripts/screenshot.py
@@ -3,8 +3,8 @@ from tamga import Tamga
 logger = Tamga(
     show_time=True,
     show_timezone=False,
-    is_colored=True,
-    log_to_console=True,
+    colored_output=True,
+    console_output=True,
 )
 
 print("\n")

--- a/tamga/main.py
+++ b/tamga/main.py
@@ -24,29 +24,29 @@ class Tamga:
     LOG_LEVELS = LOG_LEVELS
 
     __slots__ = [
-        "is_colored",
-        "log_to_file",
-        "log_to_json",
-        "log_to_console",
-        "log_to_mongo",
-        "log_to_sql",
-        "show_day",
+        "colored_output",
+        "file_output",
+        "json_output",
+        "console_output",
+        "mongo_output",
+        "sql_output",
+        "show_date",
         "show_time",
         "show_timezone",
         "mongo_uri",
         "mongo_database_name",
         "mongo_collection_name",
-        "log_file",
+        "json_path",
         "log_json",
-        "log_sql",
-        "sql_table",
+        "sql_path",
+        "sql_table_name",
         "notify_services",
         "notify_levels",
         "notify_title",
         "notify_format",
         "max_log_size",
-        "max_json_size",
-        "max_sql_size",
+        "max_json_size_mb",
+        "max_sql_size_mb",
         "enable_backup",
         "buffer_size",
         "max_level_width",
@@ -58,34 +58,34 @@ class Tamga:
         "_buffer_lock",
         "_color_cache",
         "_json_file_handle",
-        "_log_file_handle",
+        "_json_path_handle",
     ]
 
     def __init__(
         self,
-        is_colored: bool = True,
-        log_to_file: bool = False,
-        log_to_json: bool = False,
-        log_to_console: bool = True,
-        log_to_mongo: bool = False,
-        log_to_sql: bool = False,
-        show_day: bool = True,
+        colored_output: bool = True,
+        file_output: bool = False,
+        json_output: bool = False,
+        console_output: bool = True,
+        mongo_output: bool = False,
+        sql_output: bool = False,
+        show_date: bool = True,
         show_time: bool = True,
         show_timezone: bool = False,
         mongo_uri: str = None,
         mongo_database_name: str = "tamga",
         mongo_collection_name: str = "logs",
-        log_file: str = "tamga.log",
+        json_path: str = "tamga.log",
         log_json: str = "tamga.json",
-        log_sql: str = "tamga.db",
-        sql_table: str = "logs",
+        sql_path: str = "tamga.db",
+        sql_table_name: str = "logs",
         notify_services: list = None,
         notify_levels: list = [],
         notify_title: str = "{appname}: {level} - {date}",
         notify_format: str = "text",
         max_log_size: int = 10,
-        max_json_size: int = 10,
-        max_sql_size: int = 50,
+        max_json_size_mb: int = 10,
+        max_sql_size_mb: int = 50,
         enable_backup: bool = True,
         buffer_size: int = 50,
     ):
@@ -93,55 +93,55 @@ class Tamga:
         Initialize Tamga with optional features.
 
         Args:
-            is_colored: Enable colored console output (default: True)
-            log_to_file: Enable logging to a file (default: False)
-            log_to_json: Enable logging to a JSON file (default: False)
-            log_to_console: Enable logging to console (default: True)
-            log_to_mongo: Enable logging to MongoDB (default: False)
-            log_to_sql: Enable logging to SQL database (default: False)
-            show_day: Show day in console logs (default: True)
+            colored_output: Enable colored console output (default: True)
+            file_output: Enable logging to a file (default: False)
+            json_output: Enable logging to a JSON file (default: False)
+            console_output: Enable logging to console (default: True)
+            mongo_output: Enable logging to MongoDB (default: False)
+            sql_output: Enable logging to SQL database (default: False)
+            show_date: Show day in console logs (default: True)
             show_time: Show time in console logs (default: True)
             show_timezone: Show timezone in console logs (default: False)
             mongo_uri: MongoDB connection URI
             mongo_database_name: MongoDB database name (default: "tamga")
             mongo_collection_name: MongoDB collection name (default: "logs")
-            log_file: Path to the log file (default: "tamga.log")
+            json_path: Path to the log file (default: "tamga.log")
             log_json: Path to the JSON log file (default: "tamga.json")
-            log_sql: Path to the SQL log file (default: "tamga.db")
-            sql_table: SQL table name for logs (default: "logs")
+            sql_path: Path to the SQL log file (default: "tamga.db")
+            sql_table_name: SQL table name for logs (default: "logs")
             notify_services: List of Apprise notification service URLs
             notify_levels: List of log levels to send notifications for (default: includes NOTIFY)
             notify_title: Template for notification titles (default: "{appname}: {level} - {date}")
             notify_format: Notification format type - text/markdown/html (default: "text")
             max_log_size: Maximum size in MB for log file (default: 10)
-            max_json_size: Maximum size in MB for JSON file (default: 10)
-            max_sql_size: Maximum size in MB for SQL file (default: 50)
+            max_json_size_mb: Maximum size in MB for JSON file (default: 10)
+            max_sql_size_mb: Maximum size in MB for SQL file (default: 50)
             enable_backup: Enable backup when max size is reached (default: True)
             buffer_size: Number of logs to buffer before writing to file (default: 50)
         """
-        self.is_colored = is_colored
-        self.log_to_file = log_to_file
-        self.log_to_json = log_to_json
-        self.log_to_console = log_to_console
-        self.log_to_mongo = log_to_mongo
-        self.log_to_sql = log_to_sql
-        self.show_day = show_day
+        self.colored_output = colored_output
+        self.file_output = file_output
+        self.json_output = json_output
+        self.console_output = console_output
+        self.mongo_output = mongo_output
+        self.sql_output = sql_output
+        self.show_date = show_date
         self.show_time = show_time
         self.show_timezone = show_timezone
         self.mongo_uri = mongo_uri
         self.mongo_database_name = mongo_database_name
         self.mongo_collection_name = mongo_collection_name
-        self.log_file = log_file
+        self.json_path = json_path
         self.log_json = log_json
-        self.log_sql = log_sql
-        self.sql_table = sql_table
+        self.sql_path = sql_path
+        self.sql_table_name = sql_table_name
         self.notify_services = notify_services or []
         self.notify_title = notify_title
         self.notify_format = notify_format
         self.notify_levels = list(set(notify_levels + ["NOTIFY"]))
         self.max_log_size = max_log_size
-        self.max_json_size = max_json_size
-        self.max_sql_size = max_sql_size
+        self.max_json_size_mb = max_json_size_mb
+        self.max_sql_size_mb = max_sql_size_mb
         self.enable_backup = enable_backup
         self.buffer_size = buffer_size
         self.max_level_width = max(len(level) for level in self.LOG_LEVELS)
@@ -153,27 +153,27 @@ class Tamga:
         self._buffer_lock = threading.Lock()
         self._color_cache = {}
         self._json_file_handle = None
-        self._log_file_handle = None
+        self._json_path_handle = None
         self._init_services()
 
     def _init_services(self):
         """Initialize external services and create necessary files."""
-        if self.log_to_mongo:
+        if self.mongo_output:
             self._init_mongo()
 
-        if self.log_to_file:
-            self._ensure_file_exists(self.log_file)
+        if self.file_output:
+            self._ensure_file_exists(self.json_path)
             try:
-                self._log_file_handle = open(
-                    self.log_file, "a", encoding="utf-8", buffering=8192
+                self._json_path_handle = open(
+                    self.json_path, "a", encoding="utf-8", buffering=8192
                 )
             except Exception:
                 pass
 
-        if self.log_to_json:
+        if self.json_output:
             self._init_json_file()
 
-        if self.log_to_sql:
+        if self.sql_output:
             self._init_sql_db()
 
     def _init_mongo(self):
@@ -274,10 +274,10 @@ class Tamga:
 
     def _init_sql_db(self):
         """Initialize SQLite database."""
-        self._ensure_file_exists(self.log_sql)
-        with sqlite3.connect(self.log_sql) as conn:
+        self._ensure_file_exists(self.sql_path)
+        with sqlite3.connect(self.sql_path) as conn:
             conn.execute(
-                f"""CREATE TABLE IF NOT EXISTS {self.sql_table}
+                f"""CREATE TABLE IF NOT EXISTS {self.sql_table_name}
                 (level TEXT, message TEXT, date TEXT, time TEXT,
                 timezone TEXT, timestamp REAL)"""
             )
@@ -291,7 +291,7 @@ class Tamga:
     def _format_timestamp(self) -> str:
         """Format timestamp string based on settings."""
         parts = []
-        if self.show_day:
+        if self.show_date:
             parts.append(current_date())
         if self.show_time:
             parts.append(current_time())
@@ -301,7 +301,7 @@ class Tamga:
 
     def _log_internal(self, message: str, level: str, color: str):
         """Internal logging for Tamga messages."""
-        if self.log_to_console:
+        if self.console_output:
             self._write_to_console(message, level, color)
 
     def log(self, message: str, level: str, color: str) -> None:
@@ -320,16 +320,16 @@ class Tamga:
             "unix_timestamp": current_timestamp(),
         }
 
-        if self.log_to_console:
+        if self.console_output:
             self._write_to_console(message, level, color)
 
-        if self.log_to_file:
+        if self.file_output:
             self._buffer_file_write(log_data)
 
-        if self.log_to_json:
+        if self.json_output:
             self._buffer_json_write(log_data)
 
-        if self.log_to_sql:
+        if self.sql_output:
             self._write_to_sql(log_data)
 
         if level in self.notify_levels and self.notify_services:
@@ -338,7 +338,7 @@ class Tamga:
 
             self._send_notification_async(message, level)
 
-        if self.log_to_mongo:
+        if self.mongo_output:
             self._write_to_mongo_async(log_data)
 
     def _buffer_file_write(self, log_data: Dict[str, Any]):
@@ -360,18 +360,18 @@ class Tamga:
         if not self._file_buffer:
             return
 
-        self._handle_file_rotation(self.log_file, self.max_log_size)
+        self._handle_file_rotation(self.json_path, self.max_log_size)
 
         try:
-            if self._log_file_handle and not self._log_file_handle.closed:
+            if self._json_path_handle and not self._json_path_handle.closed:
                 for log_data in self._file_buffer:
                     file_timestamp = f"{log_data['date']} | {log_data['time']} | {log_data['timezone']}"
-                    self._log_file_handle.write(
+                    self._json_path_handle.write(
                         f"[{file_timestamp}] {log_data['level']}: {log_data['message']}\n"
                     )
-                self._log_file_handle.flush()
+                self._json_path_handle.flush()
             else:
-                with open(self.log_file, "a", encoding="utf-8") as f:
+                with open(self.json_path, "a", encoding="utf-8") as f:
                     for log_data in self._file_buffer:
                         file_timestamp = f"{log_data['date']} | {log_data['time']} | {log_data['timezone']}"
                         f.write(
@@ -386,7 +386,7 @@ class Tamga:
         if not self._json_buffer:
             return
 
-        self._handle_file_rotation(self.log_json, self.max_json_size)
+        self._handle_file_rotation(self.log_json, self.max_json_size_mb)
 
         try:
             with open(self.log_json, "r+", encoding="utf-8") as f:
@@ -431,7 +431,7 @@ class Tamga:
 
     def _write_to_console(self, message: str, level: str, color: str):
         """Write formatted log entry to console."""
-        if not self.is_colored:
+        if not self.colored_output:
             timestamp = self._format_timestamp()
             if timestamp:
                 print(f"[ {timestamp} ]  {level:<{self.max_level_width}}  {message}")
@@ -443,12 +443,12 @@ class Tamga:
 
         output_parts = []
 
-        if self.show_day or self.show_time or self.show_timezone:
+        if self.show_date or self.show_time or self.show_timezone:
             output_parts.append(f"{Color.text('gray')}[{Color.end_code}")
 
             content_parts = []
 
-            if self.show_day:
+            if self.show_date:
                 content_parts.append(
                     f"{Color.text('indigo')}{current_date()}{Color.end_code}"
                 )
@@ -483,12 +483,12 @@ class Tamga:
 
     def _write_to_sql(self, log_data: Dict[str, Any]):
         """Write log entry to SQL database."""
-        self._handle_file_rotation(self.log_sql, self.max_sql_size)
+        self._handle_file_rotation(self.sql_path, self.max_sql_size_mb)
 
         try:
-            with sqlite3.connect(self.log_sql) as conn:
+            with sqlite3.connect(self.sql_path) as conn:
                 conn.execute(
-                    f"INSERT INTO {self.sql_table} VALUES (?, ?, ?, ?, ?, ?)",
+                    f"INSERT INTO {self.sql_table_name} VALUES (?, ?, ?, ?, ?, ?)",
                     (
                         log_data["level"],
                         log_data["message"],
@@ -557,9 +557,9 @@ class Tamga:
         if not self._check_file_size(filepath, max_size_mb):
             return
 
-        if filepath == self.log_file and self._log_file_handle:
-            self._log_file_handle.close()
-            self._log_file_handle = None
+        if filepath == self.json_path and self._json_path_handle:
+            self._json_path_handle.close()
+            self._json_path_handle = None
 
         if self.enable_backup:
             self._create_backup(filepath)
@@ -570,13 +570,13 @@ class Tamga:
                     json.dump([], f)
             elif filepath.endswith(".db"):
                 with sqlite3.connect(filepath) as conn:
-                    conn.execute(f"DELETE FROM {self.sql_table}")
+                    conn.execute(f"DELETE FROM {self.sql_table_name}")
             else:
                 open(filepath, "w", encoding="utf-8").close()
 
-            if filepath == self.log_file:
-                self._log_file_handle = open(
-                    self.log_file, "a", encoding="utf-8", buffering=8192
+            if filepath == self.json_path:
+                self._json_path_handle = open(
+                    self.json_path, "a", encoding="utf-8", buffering=8192
                 )
         except Exception as e:
             self._log_internal(f"Failed to rotate file: {e}", "ERROR", "red")
@@ -596,8 +596,8 @@ class Tamga:
             if self._notify_executor:
                 self._notify_executor.shutdown(wait=False)
 
-            if self._log_file_handle and not self._log_file_handle.closed:
-                self._log_file_handle.close()
+            if self._json_path_handle and not self._json_path_handle.closed:
+                self._json_path_handle.close()
         except Exception:
             pass
 


### PR DESCRIPTION
Renamed Tamga configuration parameters and internal variables for clarity and consistency (e.g., log_to_file -> file_output, is_colored -> colored_output, log_file -> json_path, show_day -> show_date, etc.). Updated all usage in documentation, examples, main implementation, and tests to match the new parameter names. This improves code readability and aligns naming conventions across the project.

Fixes #

## Proposed Changes

-
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation and example code to use new, more consistent configuration parameter names for the Tamga logger.
  * Revised comments and usage examples to match the new naming conventions.

* **Refactor**
  * Renamed logger configuration parameters and internal attributes for improved clarity and consistency across the codebase and tests.

* **Tests**
  * Updated test cases to reflect the new parameter names, ensuring consistency with the revised configuration scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->