### PR TITLE
Differentiate DIR log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ A modern, high-performance logging utility for Python with multiple output forma
 - 🔄 **Automatic Rotation** - File size management with backup support
 - 🧵 **Thread-Safe** - Safe for multi-threaded applications
 - 🔔 **Notifications** - Multi-service notifications via [Apprise](https://github.com/caronc/apprise) (Discord, Slack, Email, SMS, and more)
-- 🔍 **Structured Logging** - Key-value data support with `dir()` method
+- 🔍 **Structured Logging** - Key-value data support via `**kwargs` on any log level
+- 📂 **DIR Pretty Print** - Multi-line output for `logger.dir()`
 
 ## 🚀 Quick Start
 
@@ -78,11 +79,12 @@ logger = Tamga(
 ### Structured Logging
 ```python
 # Log with key-value data
-logger.dir("User action",
+logger.dir(
+    "User action",
     user_id="123",
     action="login",
     ip_address="192.168.1.1",
-    success=True
+    success=True,
 )
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -225,11 +225,12 @@ logger.warning("High memory usage")  # WARNING not in notify_levels
 logger.custom("Deploy completed", "DEPLOY", "purple")
 
 # Structured logging with key-value data
-logger.dir("User action",
+logger.dir(
+    "User action",
     user_id="123",
     action="login",
     ip_address="192.168.1.1",
-    success=True
+    success=True,
 )
 ```
 
@@ -381,21 +382,23 @@ def log_request(request):
     start_time = time.time()
 
     # Log request details
-    logger.dir("Request started",
+    logger.dir(
+        "Request started",
         request_id=request_id,
         method=request.method,
         path=request.path,
-        ip=request.remote_addr
+        ip=request.remote_addr,
     )
 
     try:
         response = process(request)
         duration = time.time() - start_time
 
-        logger.dir("Request completed",
+        logger.dir(
+            "Request completed",
             request_id=request_id,
             status=response.status_code,
-            duration_ms=round(duration * 1000)
+            duration_ms=round(duration * 1000),
         )
 
         return response
@@ -422,10 +425,11 @@ logger = Tamga(
 
 # Add service context to all logs
 def log_with_context(message, level="info"):
-    logger.dir(message,
+    logger.dir(
+        message,
         service=service_name,
         version=os.getenv("VERSION"),
-        instance=os.getenv("INSTANCE_ID")
+        instance=os.getenv("INSTANCE_ID"),
     )
 ```
 
@@ -575,9 +579,10 @@ logger = Tamga(
 
 # Application usage
 logger.info("Application starting")
-logger.dir("Configuration loaded",
+logger.dir(
+    "Configuration loaded",
     environment=os.getenv("ENV"),
-    debug_mode=True
+    debug_mode=True,
 )
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tamga"
-version = "1.3.1"
+version = "1.3.2"
 authors = [{ name = "Doğukan Ürker", email = "dogukanurker@icloud.com" }]
 description = "A modern, high-performance async logging utility with multiple output formats and colorful console output"
 readme = "README.md"

--- a/tamga/__init__.py
+++ b/tamga/__init__.py
@@ -4,7 +4,7 @@ Tamga - A modern, async-capable Python logging utility
 
 from .main import Tamga
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __author__ = "Doğukan Ürker"
 __email__ = "dogukanurker@icloud.com"
 __license__ = "MIT"

--- a/tamga/main.py
+++ b/tamga/main.py
@@ -334,10 +334,25 @@ class Tamga:
         if self.console_output:
             self._write_to_console(message, level, color)
 
-    def log(self, message: str, level: str, color: str) -> None:
+    def log(self, message: str, level: str, color: str, **kwargs) -> None:
+        """Main logging method supporting structured key-value data.
+
+        Non-DIR levels append kwargs as a compact JSON string, while the
+        ``DIR`` level pretty prints the data on separate lines for easier
+        inspection.
         """
-        Main logging method that handles all types of logs.
-        """
+
+        if kwargs:
+            if level == "DIR":
+                data_str = json.dumps(
+                    kwargs, ensure_ascii=False, indent=2
+                ).replace('"', "'")
+                message = f"{message}\n{data_str}"
+            else:
+                data_str = json.dumps(
+                    kwargs, ensure_ascii=False, separators=(",", ":")
+                ).replace('"', "'")
+                message = f"{message} | {data_str}"
 
         log_data = {
             "message": message,
@@ -631,26 +646,33 @@ class Tamga:
         except Exception:
             pass
 
-    def info(self, message: str) -> None:
-        self.log(message, "INFO", "sky")
+    def info(self, message: str, **kwargs) -> None:
+        """Log an info level message."""
+        self.log(message, "INFO", "sky", **kwargs)
 
-    def warning(self, message: str) -> None:
-        self.log(message, "WARNING", "amber")
+    def warning(self, message: str, **kwargs) -> None:
+        """Log a warning level message."""
+        self.log(message, "WARNING", "amber", **kwargs)
 
-    def error(self, message: str) -> None:
-        self.log(message, "ERROR", "rose")
+    def error(self, message: str, **kwargs) -> None:
+        """Log an error level message."""
+        self.log(message, "ERROR", "rose", **kwargs)
 
-    def success(self, message: str) -> None:
-        self.log(message, "SUCCESS", "emerald")
+    def success(self, message: str, **kwargs) -> None:
+        """Log a success level message."""
+        self.log(message, "SUCCESS", "emerald", **kwargs)
 
-    def debug(self, message: str) -> None:
-        self.log(message, "DEBUG", "indigo")
+    def debug(self, message: str, **kwargs) -> None:
+        """Log a debug level message."""
+        self.log(message, "DEBUG", "indigo", **kwargs)
 
-    def critical(self, message: str) -> None:
-        self.log(message, "CRITICAL", "red")
+    def critical(self, message: str, **kwargs) -> None:
+        """Log a critical level message."""
+        self.log(message, "CRITICAL", "red", **kwargs)
 
-    def database(self, message: str) -> None:
-        self.log(message, "DATABASE", "green")
+    def database(self, message: str, **kwargs) -> None:
+        """Log a database level message."""
+        self.log(message, "DATABASE", "green", **kwargs)
 
     def notify(self, message: str, title: str = None, services: list = None) -> None:
         """
@@ -686,23 +708,18 @@ class Tamga:
         elif self.notify_services:
             self._send_notification_async(message, "NOTIFY", title)
 
-    def metric(self, message: str) -> None:
-        self.log(message, "METRIC", "cyan")
+    def metric(self, message: str, **kwargs) -> None:
+        """Log a metric level message."""
+        self.log(message, "METRIC", "cyan", **kwargs)
 
-    def trace(self, message: str) -> None:
-        self.log(message, "TRACE", "gray")
+    def trace(self, message: str, **kwargs) -> None:
+        """Log a trace level message."""
+        self.log(message, "TRACE", "gray", **kwargs)
 
-    def custom(self, message: str, level: str, color: str) -> None:
-        self.log(message, level, color)
+    def custom(self, message: str, level: str, color: str, **kwargs) -> None:
+        """Log a custom level message."""
+        self.log(message, level, color, **kwargs)
 
     def dir(self, message: str, **kwargs) -> None:
-        """Log message with additional key-value data."""
-        if kwargs:
-            data_str = json.dumps(
-                kwargs, ensure_ascii=False, separators=(",", ":")
-            ).replace('"', "'")
-            log_message = f"{message} | {data_str}"
-        else:
-            log_message = message
-
-        self.log(log_message, "DIR", "yellow")
+        """Pretty-print structured data using the ``DIR`` level."""
+        self.log(message, "DIR", "yellow", **kwargs)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -161,6 +161,24 @@ class TestTamgaCore(unittest.TestCase):
             self.assertIn("user_id", content)
             self.assertIn("123", content)
 
+    def test_kwargs_logging(self):
+        """Test structured logging via kwargs on standard methods."""
+        logger = Tamga(
+            console_output=False,
+            file_output=True,
+            file_path=self.file_path,
+            buffer_size=1,
+        )
+
+        logger.info("Login event", user_id=456, success=True)
+        logger.flush()
+
+        with open(self.file_path, "r") as f:
+            content = f.read()
+            self.assertIn("Login event", content)
+            self.assertIn("user_id", content)
+            self.assertIn("456", content)
+
     def test_file_rotation(self):
         """Test file rotation when size limit is reached."""
         logger = Tamga(


### PR DESCRIPTION
## Summary
- pretty-print kwargs only for the `DIR` level
- document that `logger.dir()` prints multi-line structured logs
- revert examples to use `logger.dir()` for structured logging
- update demonstration snippets

## Testing
- `python -m unittest tests.test_core -v`

------
https://chatgpt.com/codex/tasks/task_e_687210da3f948325902ed90a528444ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Structured logging now supports key-value data via keyword arguments on all log levels.
  * Enhanced pretty-printing for structured data in multi-line format using the DIR log level.

* **Documentation**
  * Updated documentation to clarify and expand details on structured logging features and usage examples.

* **Style**
  * Reformatted multi-line structured logging examples for improved readability and consistency.

* **Tests**
  * Added tests to verify structured logging with keyword arguments.

* **Chores**
  * Updated version to 1.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes #15