### PR TITLE
Add readable Tamga repr

### DIFF
--- a/tamga/main.py
+++ b/tamga/main.py
@@ -187,6 +187,25 @@ class Tamga:
 
         self._init_services()
 
+    def __repr__(self) -> str:
+        """Return the active output configuration for debugging."""
+        parts = [
+            f"console={self.console_output}",
+            f"file={self.file_output}",
+            f"json={self.json_output}",
+            f"sql={self.sql_output}",
+            f"mongo={self.mongo_output}",
+        ]
+
+        if self.file_output:
+            parts.append(f"file_path={self.file_path!r}")
+        if self.json_output:
+            parts.append(f"json_path={self.json_path!r}")
+        if self.sql_output:
+            parts.append(f"sql_path={self.sql_path!r}")
+
+        return f"Tamga({', '.join(parts)})"
+
     def _init_services(self):
         """Initialize external services and create necessary files."""
         if self.mongo_output:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,6 +27,32 @@ class TestTamgaCore(unittest.TestCase):
 
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
+    def test_repr(self):
+        """Test readable output configuration representation."""
+        logger = Tamga()
+        self.assertEqual(
+            repr(logger),
+            "Tamga(console=True, file=False, json=False, sql=False, mongo=False)",
+        )
+
+        configured_logger = Tamga(
+            console_output=False,
+            file_output=True,
+            json_output=True,
+            sql_output=True,
+            file_path=self.file_path,
+            json_path=self.json_file,
+            sql_path=self.sql_file,
+        )
+        self.assertEqual(
+            repr(configured_logger),
+            (
+                "Tamga(console=False, file=True, json=True, sql=True, mongo=False, "
+                f"file_path={self.file_path!r}, json_path={self.json_file!r}, "
+                f"sql_path={self.sql_file!r})"
+            ),
+        )
+
     def test_console_logging(self):
         """Test basic console logging functionality."""
         # Just ensure no exceptions are raised


### PR DESCRIPTION
## Summary
- add `Tamga.__repr__` with the active console, file, JSON, SQL, and Mongo output flags
- include configured file, JSON, and SQL paths only when their outputs are enabled
- cover default and multi-output representations with an exact core test

## Tests
- `python3 -m unittest tests.test_core -v`
- `uvx ruff format --check --diff .`
- `uvx ruff check --output-format=concise .`
- `python3 -m compileall -q tamga tests`

Fixes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readable representation for Tamga configurations, showing enabled output formats and their configured file paths.

* **Tests**
  * Added coverage verifying the representation for default and customized configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->