### PR TITLE
Support NO_COLOR environment variables

### DIFF
--- a/tamga/main.py
+++ b/tamga/main.py
@@ -137,6 +137,8 @@ class Tamga:
         # Output configuration
         self.console_output = console_output
         self.colored_output = colored_output
+        if "NO_COLOR" in os.environ or "TAMGA_NO_COLOR" in os.environ:
+            self.colored_output = False
         self.file_output = file_output
         self.json_output = json_output
         self.mongo_output = mongo_output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,9 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from unittest.mock import patch
 
 # Add parent directory to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -42,6 +45,44 @@ class TestTamgaCore(unittest.TestCase):
         """Test console logging without colors."""
         logger = Tamga(console_output=True, colored_output=False)
         logger.info("Test without colors")
+
+    def test_no_color_environment_variables_disable_ansi_output(self):
+        """Test NO_COLOR variables disable ANSI output when present."""
+        for env_var in ("NO_COLOR", "TAMGA_NO_COLOR"):
+            for value in ("1", ""):
+                with self.subTest(env_var=env_var, value=value):
+                    with patch.dict(os.environ, {env_var: value}, clear=True):
+                        output = StringIO()
+                        logger = Tamga(
+                            console_output=True,
+                            colored_output=True,
+                            show_date=False,
+                            show_time=False,
+                        )
+
+                        with redirect_stdout(output):
+                            logger.info("Plain output")
+
+                        self.assertFalse(logger.colored_output)
+                        self.assertNotIn("\x1b[", output.getvalue())
+                        self.assertIn("Plain output", output.getvalue())
+
+    def test_colored_output_is_unchanged_without_no_color_environment(self):
+        """Test colored console output remains enabled without env overrides."""
+        with patch.dict(os.environ, {}, clear=True):
+            output = StringIO()
+            logger = Tamga(
+                console_output=True,
+                colored_output=True,
+                show_date=False,
+                show_time=False,
+            )
+
+            with redirect_stdout(output):
+                logger.info("Colored output")
+
+            self.assertTrue(logger.colored_output)
+            self.assertIn("\x1b[", output.getvalue())
 
     def test_file_logging(self):
         """Test file logging with buffering."""


### PR DESCRIPTION
## Summary

- disable ANSI console styling when `NO_COLOR` is present
- support the Tamga-scoped `TAMGA_NO_COLOR` variable with the same presence semantics, including empty values
- preserve the existing colored console output when neither variable is set

Closes #33

## Validation

- `python3 -m unittest tests.test_core -v` (16 passed)
- `uvx ruff format --check --diff .`
- `uvx ruff check --output-format=concise .`
- `uv build --no-sources`
- `python3 -m compileall -q tamga tests`
- subprocess ANSI behavior smoke test for `NO_COLOR=""`, `TAMGA_NO_COLOR=1`, and the no-env baseline

## AI disclosure

OpenAI Codex was used to implement and test this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for disabling colored console output through the `NO_COLOR` or `TAMGA_NO_COLOR` environment variables.
  * Plain-text output is now produced when either setting is present.

* **Bug Fixes**
  * Preserved colored output behavior when no color-disabling environment variable is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->